### PR TITLE
Add support for using nil as NSLocalizedString's comment argument

### DIFF
--- a/QuickLocalization.xcodeproj/project.xcworkspace/xcshareddata/QuickLocalization.xccheckout
+++ b/QuickLocalization.xcodeproj/project.xcworkspace/xcshareddata/QuickLocalization.xccheckout
@@ -10,29 +10,29 @@
 	<string>QuickLocalization</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>B1384B3C-CDED-4974-B523-BFBC8D94735C</key>
-		<string>ssh://github.com/nanaimostudio/Xcode-Quick-Localization.git</string>
+		<key>9A578172FEED87BCB83DCEC1F373774E3DF551EF</key>
+		<string>https://github.com/lgauthier/Xcode-Quick-Localization.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>QuickLocalization.xcodeproj/project.xcworkspace</string>
+	<string>QuickLocalization.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>B1384B3C-CDED-4974-B523-BFBC8D94735C</key>
+		<key>9A578172FEED87BCB83DCEC1F373774E3DF551EF</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/nanaimostudio/Xcode-Quick-Localization.git</string>
+	<string>https://github.com/lgauthier/Xcode-Quick-Localization.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>B1384B3C-CDED-4974-B523-BFBC8D94735C</string>
+	<string>9A578172FEED87BCB83DCEC1F373774E3DF551EF</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>B1384B3C-CDED-4974-B523-BFBC8D94735C</string>
+			<string>9A578172FEED87BCB83DCEC1F373774E3DF551EF</string>
 			<key>IDESourceControlWCCName</key>
 			<string>Xcode-Quick-Localization</string>
 		</dict>

--- a/QuickLocalization/QuickLocalization.m
+++ b/QuickLocalization/QuickLocalization.m
@@ -71,7 +71,7 @@ static id sharedPlugin = nil;
             }
             NSString *string = [line substringWithRange:matchedRangeInLine];
 //            NSLog(@"string index:%d, %@", i, string);
-            NSString *outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, nil)", string, string];
+            NSString *outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, nil)", string];
             addedLength = addedLength + outputString.length - string.length;
             if ([textView shouldChangeTextInRange:matchedRangeInDocument replacementString:outputString]) {
                 [textView.textStorage replaceCharactersInRange:matchedRangeInDocument

--- a/QuickLocalization/QuickLocalization.m
+++ b/QuickLocalization/QuickLocalization.m
@@ -8,6 +8,7 @@
 
 #import "QuickLocalization.h"
 #import "RCXcode.h"
+
 static NSString *localizeRegexs[] = {
     @"NSLocalizedString\\s*\\(\\s*@\"(.*)\"\\s*,\\s*(.*)\\s*\\)",
     @"localizedStringForKey:\\s*@\"(.*)\"\\s*value:\\s*(.*)\\s*table:\\s*(.*)",
@@ -15,8 +16,18 @@ static NSString *localizeRegexs[] = {
     @"NSLocalizedStringFromTableInBundle\\s*\\(\\s*@\"(.*)\"\\s*,\\s*(.*)\\s*,\\s*(.*)\\s*,\\s*(.*)\\s*\\)",
     @"NSLocalizedStringWithDefaultValue\\s*\\(\\s*@\"(.*)\"\\s*,\\s*(.*)\\s*,\\s*(.*)\\s*,\\s*(.*)\\s*,\\s*(.*)\\s*\\)"
 };
+
 static NSString *stringRegexs = @"@\"[^\"]*\"";
+static NSString * const QLShouldUseNilForComment = @"QLShouldUseNilForComment";
+
+@interface QuickLocalization ()
+
+@property (nonatomic, assign) BOOL shouldUseNilForComment;
+
+@end
+
 @implementation QuickLocalization
+
 static id sharedPlugin = nil;
 
 
@@ -36,6 +47,9 @@ static id sharedPlugin = nil;
             [sample setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask];
             [sample setTarget:self];
             [[viewMenuItem submenu] addItem:sample];
+            NSMenuItem *nilToggle = [[NSMenuItem alloc] initWithTitle:@"Use nil for NSLocalizedString comment" action:@selector(toggleNilOption) keyEquivalent:@""];
+            [nilToggle setTarget:self];
+            [[viewMenuItem submenu] addItem:nilToggle];
         }
     }
     return self;
@@ -71,7 +85,15 @@ static id sharedPlugin = nil;
             }
             NSString *string = [line substringWithRange:matchedRangeInLine];
 //            NSLog(@"string index:%d, %@", i, string);
-            NSString *outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, nil)", string];
+            NSString *outputString;
+            
+            if ([self shouldUseNilForComment]) {
+                outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, nil)", string];
+            }
+            else {
+                outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, %@)", string, string];
+            }
+            
             addedLength = addedLength + outputString.length - string.length;
             if ([textView shouldChangeTextInRange:matchedRangeInDocument replacementString:outputString]) {
                 [textView.textStorage replaceCharactersInRange:matchedRangeInDocument
@@ -95,6 +117,29 @@ static id sharedPlugin = nil;
         }
     }
     return NO;
+}
+
+- (void)toggleNilOption {
+    [self setShouldUseNilForComment:![self shouldUseNilForComment]];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem {
+    if ([menuItem action] == @selector(toggleNilOption)) {
+        [menuItem setState:[self shouldUseNilForComment] ? NSOnState : NSOffState];
+    }
+    return YES;
+}
+
+#pragma mark Preferences
+
+- (BOOL)shouldUseNilForComment
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:QLShouldUseNilForComment];
+}
+
+- (void)setShouldUseNilForComment:(BOOL)shouldUseNilForComment
+{
+    [[NSUserDefaults standardUserDefaults] setBool:shouldUseNilForComment forKey:QLShouldUseNilForComment];
 }
 
 @end

--- a/QuickLocalization/QuickLocalization.m
+++ b/QuickLocalization/QuickLocalization.m
@@ -71,7 +71,7 @@ static id sharedPlugin = nil;
             }
             NSString *string = [line substringWithRange:matchedRangeInLine];
 //            NSLog(@"string index:%d, %@", i, string);
-            NSString *outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, %@)", string, string];
+            NSString *outputString = [NSString stringWithFormat:@"NSLocalizedString(%@, nil)", string, string];
             addedLength = addedLength + outputString.length - string.length;
             if ([textView shouldChangeTextInRange:matchedRangeInDocument replacementString:outputString]) {
                 [textView.textStorage replaceCharactersInRange:matchedRangeInDocument


### PR DESCRIPTION
With this change, there is a new menu item where the user can toggle on/off whether they want the comment argument to be nil or the original string. With this option on, @"content" would convert to NSLocalizedString(@"content", nil) instead of NSLocalizedString(@"content", @"content").
